### PR TITLE
Update link.rs to fix unused variable error

### DIFF
--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -1283,7 +1283,7 @@ fn link_output_kind(sess: &Session, crate_type: CrateType) -> LinkOutputKind {
 
 /// Whether we link to our own CRT objects instead of relying on gcc to pull them.
 /// We only provide such support for a very limited number of targets.
-fn crt_objects_fallback(sess: &Session, crate_type: CrateType) -> bool {
+fn crt_objects_fallback(sess: &Session, _crate_type: CrateType) -> bool {
     if let Some(self_contained) = sess.opts.debugging_opts.link_self_contained {
         return self_contained;
     }


### PR DESCRIPTION
For some reason, it errored when it should just be a warning.  This fixes it.